### PR TITLE
Update `advanced-issue-labeler` to `@v2`

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,36 @@
+policy:
+  - template: ['UPDATED-BUG-FORM.yml']
+    section:
+      - id: ['issue_type']
+        block-list: []
+        label:
+          - name: '🐛 Bug'
+            keys: ['🐛 Bug']
+          - name: '🛠 Improvement'
+            keys: ['🛠 Improvement']
+
+      - id: ['priority']
+        block-list: []
+        label:
+          - name: '⚠️ Minor'
+            keys: ['⚠️ Minor']
+          - name: '❗️ Major'
+            keys: ['❗️ Major']
+          - name: '❗️❗️ Critical'
+            keys: ['❗️❗️ Critical']
+          - name: '⛔️ Blocker'
+            keys: ['⛔️ Blocker']
+
+      - id: ['components']
+        block-list: ['Other']
+        label:
+          - name: 'Student Guide'
+            keys: ['Student Guide']
+          - name: 'Instructor Guide'
+            keys: ['Instructor Guide']
+          - name: 'Lab Environment'
+            keys: ['Lab Environment']
+          - name: 'Video Classroom'
+            keys: ['Video Classroom']
+          - name: 'Slides'
+            keys: ['Slides']

--- a/.github/workflows/github-actions-issue-labeler.yml
+++ b/.github/workflows/github-actions-issue-labeler.yml
@@ -2,38 +2,33 @@ name: Issue Labeler
 on:
   issues:
     types: [ opened ]
+
+permissions:
+  contents: read
+
 jobs:
   label-issue-type:
     runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+
+    strategy:
+      matrix:
+        template: [ UPDATED-BUG-FORM.yml ]
+
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-
       - name: Parse issue form
-        uses: stefanbuck/github-issue-praser@v2
+        uses: stefanbuck/github-issue-parser@v2
         id: issue-parser
         with:
-          template-path: .github/ISSUE_TEMPLATE/UPDATED-BUG-FORM.yml
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
 
-      - name: Set labels based on issue_type field
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@v1
+      - name: Set labels based on user input
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
-          section: issue_type
+          template: ${{ matrix.template }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set labels based on priority field
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@v1
-        with:
-          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
-          section: priority
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set labels based on components
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@v1
-        with:
-          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
-          section: components
-          token: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
The new major version of `advanced-issue-labeler` allows you to simplify your issue-labeling workflow.

> **Note**: I have added permissions to make workflow more secure and remove node.js setup GitHub Action since you don't execute any javascript directly from your workflow.